### PR TITLE
🐛 :: 액션 시트에서 앨범선택 시 카메라 뷰 노출 수정 #KAN-178

### DIFF
--- a/Frontend-iOS/FebirdApp/FebirdApp/Sources/Onboarding/Views/InbodyAddView.swift
+++ b/Frontend-iOS/FebirdApp/FebirdApp/Sources/Onboarding/Views/InbodyAddView.swift
@@ -112,11 +112,15 @@ struct InbodyAddView: View {
         }
         .padding(.horizontal, 24)
         .cameraActionSheet(isPresented: $showActionSheet) {
-            self.sourceType = .camera
-            self.showImagePicker = true
+            DispatchQueue.main.async {
+                self.sourceType = .camera
+                self.showImagePicker = true
+            }
         } onGalleryTap: {
-            self.sourceType = .photoLibrary
-            self.showImagePicker = true
+            DispatchQueue.main.async {
+                self.sourceType = .photoLibrary
+                self.showImagePicker = true
+            }
         }
         .sheet(isPresented: $showImagePicker) {
             PhotoPicker(image: $image, isPresented: $showImagePicker, sourceType: sourceType)


### PR DESCRIPTION
- 액션 시트에서 불러오기 선택 시 카메라 모달이 뜨는 것을 수정했습니다. 