### PR TITLE
✨ :: 수정요청 확인 후 type 칼럼, exercise table수정 #KAN-206

### DIFF
--- a/Backend/febird-api/src/exercise/dto/create-exercise.dto.ts
+++ b/Backend/febird-api/src/exercise/dto/create-exercise.dto.ts
@@ -7,9 +7,13 @@ export class CreateExerciseDto {
 
   @IsString()
   @IsNotEmpty()
-  url: string;
+  video_guide_url: string;
 
   @IsString()
   @IsNotEmpty()
   tip: string;
+
+  @IsString()
+  @IsNotEmpty()
+  type: string;
 }

--- a/Backend/febird-api/src/exercise/exercise.entity.ts
+++ b/Backend/febird-api/src/exercise/exercise.entity.ts
@@ -9,11 +9,14 @@ export class Exercise {
   @Column({ length: 50 })
   exercise_name: string;
 
-  @Column('text')
-  url: string;
+  @Column({ length: 255 })
+  video_guide_url: string;
 
   @Column('text')
   tip: string;
+
+  @Column({ length: 3 })
+  type: string;
 
   @OneToMany(() => Routine, (routine) => routine.exercise)
   routines: Routine[];

--- a/Backend/febird-api/src/level/dto/create-level.dto.ts
+++ b/Backend/febird-api/src/level/dto/create-level.dto.ts
@@ -1,9 +1,13 @@
-import { IsNotEmpty, IsNumber, IsString } from 'class-validator';
+import { IsNotEmpty, IsNumber, IsString, IsInt } from 'class-validator';
 
 export class CreateLevelDto {
   @IsString()
   @IsNotEmpty()
   school_name: string;
+
+  @IsNotEmpty()
+  @IsInt()
+  grade: number;
 
   @IsNumber()
   @IsNotEmpty()

--- a/Backend/febird-api/src/level/dto/update-level.dto.ts
+++ b/Backend/febird-api/src/level/dto/update-level.dto.ts
@@ -1,9 +1,13 @@
 import { PartialType } from '@nestjs/swagger';
 import { CreateLevelDto } from './create-level.dto';
-import { IsString, IsNotEmpty } from 'class-validator';
+import { IsString, IsNotEmpty, IsInt } from 'class-validator';
 
 export class UpdateLevelDto extends PartialType(CreateLevelDto) {
     @IsString()
     @IsNotEmpty()
     school_name: string;
+
+    @IsNotEmpty()
+    @IsInt()
+    grade: number;
 }

--- a/Backend/febird-api/src/level/level.entity.ts
+++ b/Backend/febird-api/src/level/level.entity.ts
@@ -10,6 +10,9 @@ export class Level {
   @Column({ length: 50 })
   school_name: string;
 
+  @Column()
+  grade: number;
+
   @OneToMany(() => Routine, (routine) => routine.level)
   routines: Routine[]
 

--- a/Backend/febird-api/src/routine/dto/create-routine.dto.ts
+++ b/Backend/febird-api/src/routine/dto/create-routine.dto.ts
@@ -11,10 +11,6 @@ export class CreateRoutineDto {
   @IsNotEmpty()
   set: number;
 
-  @IsString()
-  @IsNotEmpty()
-  type: string;
-
   @IsArray()
   @IsNotEmpty()
   levels: CreateLevelDto[];

--- a/Backend/febird-api/src/routine/routine.entity.ts
+++ b/Backend/febird-api/src/routine/routine.entity.ts
@@ -13,9 +13,6 @@ export class Routine {
   @Column()
   set: number;
 
-  @Column({ length: 3 })
-  type: string;
-
   @ManyToOne(() => Level, (level) => level.routines)
   @JoinColumn({ name: 'level_id' })
   level: Level;


### PR DESCRIPTION
### 작업내용
1. type 칼럼을 routine table -> exercise table로 이동
2. exercise table에 grade: int 추가 
3. exercise table에 url -> video_guide_url로 변경

### 참고사항

- 씨앗반(level: 1, grade: 1) 
 운동(466512^Overhead_Clap^Shoulders), Type: C
 3회 2세트
- 새싹반(level: 2, grade: 2) 
 운동(510912^Downward_Punch^Shoulders), Type: C
 5회 2세트
- 열매반(level: 3, grade: 3) 
  운동(80212^Sumo_Squat^Hips_Thighs), Type: C
  5회 3세트

### 스크린샷 
<img width="393" alt="image" src="https://github.com/user-attachments/assets/e11bc018-febb-4fb5-90e4-f30fed492196">
