### PR TITLE
식단탭 메모 수정

### DIFF
--- a/Frontend-iOS/FebirdApp/FebirdApp/Sources/Meal/Views/Components/MemoRow.swift
+++ b/Frontend-iOS/FebirdApp/FebirdApp/Sources/Meal/Views/Components/MemoRow.swift
@@ -26,9 +26,9 @@ struct MemoRow: View {
         HStack(spacing: 8) {
             Image(uiImage: mealImage ?? UIImage(named: "feoFace")!)
                 .resizable()
-                .scaledToFit()
-                .frame(height: 70)
-                .cornerRadius(8)
+                .scaledToFill()
+                .frame(width: 70, height: 70)
+                .cornerRadius(10)
 
             VStack(alignment: .leading, spacing: 8) {
                 Text(mealTime)

--- a/Frontend-iOS/FebirdApp/FebirdApp/Sources/Meal/Views/MemoModalView.swift
+++ b/Frontend-iOS/FebirdApp/FebirdApp/Sources/Meal/Views/MemoModalView.swift
@@ -74,14 +74,8 @@ struct MemoModalView: View {
                 Image(uiImage: image ?? UIImage(named: "uploadIcon")!)
                     .resizable()
                     .scaledToFit()
-                    .frame(height: image == UIImage(named: "uploadIcon") ? 50 : 200)
+                    .frame(height: image == nil || image == UIImage(named: "uploadIcon") ? 70 : 200)
                     .cornerRadius(10)
-
-                if image == UIImage(named: "uploadIcon") {
-                    Text("이미지 등록하기")
-                        .font(.customFont(size: 14, weight: .medium))
-                        .foregroundStyle(.gray60)
-                }
             }
         }
         .padding()


### PR DESCRIPTION


https://github.com/user-attachments/assets/fe3c3c35-47a4-4c70-8b29-2d5e99c3aa22


## 수정사항
- 텍스트 색상 gray100으로 변환
- 타이틀 추가
- MemoRow에 작성된 텍스트 모달뷰에서 수정할 수 있도록 함
- 추가한 이미지 위치 고정