### PR TITLE
🛠️ :: ChatViewModel & MemberViewModel DO NOT USE do-catch

### DIFF
--- a/Frontend-iOS/FebirdApp/FebirdApp/Sources/NetworkService/Chat/ChatViewModel.swift
+++ b/Frontend-iOS/FebirdApp/FebirdApp/Sources/NetworkService/Chat/ChatViewModel.swift
@@ -34,22 +34,18 @@ class ChatViewModel: ObservableObject {
                 ["role": "user", "content": content]
             ]
         ]
-
-        do {
-            let request = AF.request(url, method: .post, parameters: body, encoding: JSONEncoding.default, headers: headers)
-
-            let response = try await request.serializingDecodable(ChatResponse.self).response
-
-            switch response.result {
+        
+        let request = AF.request(url, method: .post, parameters: body, encoding: JSONEncoding.default, headers: headers)
+        
+        let response = await request.serializingDecodable(ChatResponse.self).response
+        
+        switch response.result {
             case .success(let chatResponse):
                 if let message = chatResponse.choices.first?.message {
                     messages.append(message)
                 }
             case .failure(let error):
                 handleError(error)
-            }
-        } catch {
-            handleError(error)
         }
     }
 

--- a/Frontend-iOS/FebirdApp/FebirdApp/Sources/NetworkService/Member/MemberViewModel.swift
+++ b/Frontend-iOS/FebirdApp/FebirdApp/Sources/NetworkService/Member/MemberViewModel.swift
@@ -29,23 +29,18 @@ class MemberViewModel: ObservableObject {
             "Content-Type": "application/json",
             "appleID": appleID
         ]
-
-        do {
-            let request = AF.request(url, method: .post, headers: headers)
-
-            let response = try await request.serializingDecodable(LoginResponse.self).response
-
-            switch response.result {
+        
+        let request = AF.request(url, method: .post, headers: headers)
+        
+        let response = await request.serializingDecodable(LoginResponse.self).response
+        
+        switch response.result {
             case .success(let loginResponse):
                 print("JWT 토큰: \(loginResponse.token)")
                 // 받은 토큰을 저장하거나, 다음 작업을 수행합니다.
             case .failure(let error):
                 self.errorMessage = error.localizedDescription
                 print("Error creating member: \(error)")
-            }
-        } catch {
-            self.errorMessage = error.localizedDescription
-            print("Error creating member: \(error)")
         }
     }
 


### PR DESCRIPTION
해당 로직들에 사용된 response의 타입이 [DataResponse]<[LoginResponse], [AFError]>와 같이 응답과 에러를 같이 받고 하단에 switch 구문을 통해 에러를 처리하기 때문에 기존 코드의 do-catch와 try를 활용한 에러핸들링은 불필요한 부분이라고 생각했습니다.
```
let response = await request.serializingDecodable(LoginResponse.self).response

switch response.result {
    case .success(let loginResponse):
        print("JWT 토큰: \(loginResponse.token)")
        // 받은 토큰을 저장하거나, 다음 작업을 수행합니다.
    case .failure(let error):
        self.errorMessage = error.localizedDescription
        print("Error creating member: \(error)")
}
```

p.s. 실행해보고 싶지만 Secret.xcconfig 파일이 없어서 실행시켜보지 모태따...